### PR TITLE
Add user-defined search engines

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,7 @@
 var App = {
+  localStorageKey: "r4find",
+  userEngines: localStorage.getItem(localStorageKey) || {},
+
 	doEngines: {
 		r4: 'https://radio4000.com/add?url='
 	},
@@ -33,10 +36,19 @@ var App = {
 			engines: {
 				r4: 'https://radio4000.com/add?url='
 			}
-		}
+		},
+    '/': {
+      name: 'command',
+      fns: {
+        add: function(arg) {
+          let [name, url] = arg.split(" ");
+          addUserEngine(name, url);
+        }
+      }
+    }
 	},
 
-	// returns a result url stirng to open
+	// returns a result url string to open
 	// default to "search for help if only a symbol"
 	buildResult(userQuery, symbol = '!', engineId = 'd') {
 		var engineUrl = this.symbols[symbol].engines[engineId];
@@ -101,11 +113,25 @@ var App = {
 	},
 
 	init() {
+    refreshUserEngines();
 		var url = new URL(window.location.href);
 		var request = url.searchParams.get('q');
 		if(!request) return;
 		this.find(request);
 	}
+
+  addUserEngine(name, url) {
+    userEngines[name] = url;
+    localStorage.setItem(localStorageKey, userEngines);
+    refreshUserEngines();
+  }
+
+  refreshUserEngines() {
+    for (var name in userEngines) {
+      var url = userEngines[url];
+      this.symbols["!"]["engines"][name] = url;
+    }
+  }
 };
 
 App.init();

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 var App = {
   localStorageKey: "r4find",
-  userEngines: localStorage.getItem(localStorageKey) || {},
+  /* we can’t use localStorageKey here, because it’s undefined */
+  userEngines: JSON.parse(localStorage.getItem("r4find")) || {},
 
 	doEngines: {
 		r4: 'https://radio4000.com/add?url='
@@ -37,12 +38,12 @@ var App = {
 				r4: 'https://radio4000.com/add?url='
 			}
 		},
-    '/': {
+    '#': {
       name: 'command',
       fns: {
-        add: function(arg) {
-          let [_, name, url] = arg.split(" ");
-          addUserEngine(name, url);
+        add: function(app, arg) {
+          let [name, url] = arg.split(" ");
+          app.addUserEngine(name, url);
         }
       }
     }
@@ -54,7 +55,7 @@ var App = {
 		var symbol = this.symbols[symbol];
 
     if (symbol.fns) {
-      return symbol.fns[engineId](userRequest):
+      return symbol.fns[engineId](this, userQuery);
     }
     
     var engineUrl = symbol.engines[engineId];
@@ -69,7 +70,17 @@ var App = {
 		return availableSymbols.indexOf(symbol) >= 0 ? symbol : false;
 	},
 	checkForEngine(symbol, engineId) {
-		return this.symbols[symbol].engines[engineId] ? engineId : false;
+    var engines =  this.symbols[symbol].engines;
+    var fns =  this.symbols[symbol].fns;
+		if (engines) {
+      return engines[engineId] ? engineId : false;
+    }
+
+    if (fns) {
+      return fns[engineId] ? engineId : false;
+    }
+
+    return false;
 	},
 
 	// param:
@@ -119,25 +130,25 @@ var App = {
 	},
 
 	init() {
-    refreshUserEngines();
+    this.refreshUserEngines();
 		var url = new URL(window.location.href);
 		var request = url.searchParams.get('q');
 		if(!request) return;
 		this.find(request);
-	}
+	},
 
   addUserEngine(name, url) {
-    userEngines[name] = url;
-    localStorage.setItem(localStorageKey, userEngines);
-    refreshUserEngines();
-  }
+    this.userEngines[name] = url;
+    localStorage.setItem(this.localStorageKey, JSON.stringify(this.userEngines));
+    this.refreshUserEngines();
+  },
 
   refreshUserEngines() {
-    for (var name in userEngines) {
-      var url = userEngines[url];
+    for (var name in this.userEngines) {
+      var url = this.userEngines[name];
       this.symbols["!"]["engines"][name] = url;
     }
-  }
+  },
 };
 
 App.init();

--- a/main.js
+++ b/main.js
@@ -41,7 +41,7 @@ var App = {
       name: 'command',
       fns: {
         add: function(arg) {
-          let [name, url] = arg.split(" ");
+          let [_, name, url] = arg.split(" ");
           addUserEngine(name, url);
         }
       }
@@ -51,7 +51,13 @@ var App = {
 	// returns a result url string to open
 	// default to "search for help if only a symbol"
 	buildResult(userQuery, symbol = '!', engineId = 'd') {
-		var engineUrl = this.symbols[symbol].engines[engineId];
+		var symbol = this.symbols[symbol];
+
+    if (symbol.fns) {
+      return symbol.fns[engineId](userRequest):
+    }
+    
+    var engineUrl = symbol.engines[engineId];
 		return engineUrl + userQuery;
 	},
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ us find what we're looking for.
 Overhall we use it as a CLI (command line interface) to complete
 actions on the web. In Chrome/Chromium, Google calls it the
 Omnibox. Omni, the Latin prefix meaning "all" or "every", since we use
-it to *input everything**.
+it to *input everything*.
 
 *Find!* aims to be a simple way to enhance your experience, easy to
 setup and use. Also, it is Free software, and can be customized and

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,10 @@ But all the idea with `Find!` is to use the following `!keywords`
 | ---             | ---                                             |
 | +r4             | radio4000.com add a new track from URL          |
 
+| Function keyword      | site                                            |
+| ---                   | ---                                             |
+| #add \<name\> \<url\> | add a custom `!` search, e.g. `#add gh https://github.com/search?q=` |
+
 To use these triggers, for exemple with the search query `foo`:
 - Put your cursor in the URL bar of your browser
 - Type the website's `!keyword` (the website on which you want to


### PR DESCRIPTION
This PR adds adding user-defined engines. It introduces a new symbol `#` for commands. The command that was added is `#add <name> <url>`. As an example, you could use `#add gh https://github.com/search?q=`. It will then be added to the engines under the symbol `!`.

I’m not dead-set on the API, i.e. the symbol could be changed. From a UX standpoint, it is also annoying that the user will just be redirected to `find` once such a command was issued, without a message whether the command succeeded. This should probably be fixed.

If you want to try this out, an example live version can be found on [my private domain](https://veitheller.de/find/).

If you have any questions as to how this works (spoiler: it uses the `localStorage` API), ask away!

Cheers