### PR TITLE
feat: add google actions for doc, sheet, draw, gmail

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,7 +35,11 @@ var App = {
 		'+': {
 			name: 'do',
 			engines: {
-				r4: 'https://radio4000.com/add?url='
+				r4: 'https://radio4000.com/add?url=',
+				draw: 'https://docs.google.com/drawings/create?title=',
+				doc: 'https://docs.google.com/document/create?title=',
+				sheet: 'https://docs.google.com/spreadsheets/create?title=',
+				gmail: 'https://mail.google.com/mail/#inbox?compose=new'
 			}
 		},
     '#': {
@@ -57,7 +61,7 @@ var App = {
     if (symbol.fns) {
       return symbol.fns[engineId](this, userQuery);
     }
-    
+
     var engineUrl = symbol.engines[engineId];
 		return engineUrl + userQuery;
 	},

--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,11 @@ But all the idea with `Find!` is to use the following `!keywords`
 
 | Action keyword  | site                                            |
 | ---             | ---                                             |
-| +r4             | radio4000.com add a new track from URL          |
+| +r4 [url]       | radio4000.com add a new track from URL          |
+| +draw [title]   | open a new drawing in Google Drive Draw         |
+| +doc [title]    | open a new Google Docs document                 |
+| +sheet          | open a new Google Spreadsheets document         |
+| +gmail          | open a new Gmail (Google Mail) email            |
 
 | Function keyword      | site                                            |
 | ---                   | ---                                             |


### PR DESCRIPTION
This PR adds the possibility of some new actions:
- `+draw [title]` opens a google draw with optional title
- `+doc [title]` google docs
- `+sheet` google spreadsheet (unfortunatelly no tite support)
- `+gmail` google mail new mail (no `subject`, or `to` or `body` fields, but maybe better)

At first I wanted to find a way to pass the body instead of the title (as a parameter), but it seems actually better like this, since the body is anyways too complex (and too provider specific) to manipulate.

https://mobile.twitter.com/googledocs/status/1055490445088903168 