### PR TITLE
add: service-worker.js to catch /api/suggestions fetch requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "image": "https://internet4000.github.io/find/public/favicon.ico",
     "templateHTML": "https://internet4000.github.io/find/#q={searchTerms}",
     "templateXML": "https://internet4000.github.io/find/public/opensearch.xml",
-    "templateSuggestionsJSON": "https://internet4000.github.io/find/public/opensearch.xml"
+    "templateSuggestionsJSON": "https://internet4000.github.io/find/api/suggestions/#q={searchTerms}"
   }
 }

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -2,18 +2,8 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
 	<ShortName>Find</ShortName>
 	<Description>Find anything anywhere</Description>
-	<Tags>find now productivity search</Tags>
-	<Contact>https://github.com/internet4000</Contact>
-	<Url type="text/html" template="https://internet4000.github.io/find/#q={searchTerms}" />
-	<Url type="application/opensearchdescription+xml" rel="self" template="https://internet4000.github.io/find/public/opensearch.xml" />
-	<Image height="64" width="64" type="image/png">https://internet4000.github.io/find/public/favicons/favicon-32x32.png</Image>
-	<LongName>Customize the browser omnibox URL bar with custom search engines and actions</LongName>
-	<Query role="example" searchTerms="!gh internet4000" />
-	<Developer>i4k</Developer>
-	<Attribution>gpl-v3</Attribution>
-	<SyndicationRight>open</SyndicationRight>
-	<AdultContent>false</AdultContent>
-	<Language>en-us</Language>
-	<OutputEncoding>UTF-8</OutputEncoding>
-	<InputEncoding>UTF-8</InputEncoding>
+	<Image height="64" width="64" type="image/png">http://localhost:3000/public/favicons/favicon-32x32.png</Image>
+	<Url type="text/html" template="http://localhost:3000/#q={searchTerms}" />
+	<Url type="application/opensearchdescription+xml" rel="search" template="http://localhost:3000/public/opensearch.xml" />
+	<Url type="application/x-suggestions+json" template="https://internet4000.github.io/find/api/suggestions/#q={searchTerms}" />
 </OpenSearchDescription>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,135 @@
+/* not yet supported for type module ;( */
+/* self.importScripts("./src/index.js"); */
+
+self.symbols = {};
+self.userSymbols = {};
+self.allSymbols = {};
+self.allEngines = [];
+
+/* mock find/osd until we can import it */
+const Find = {
+	suggestSymbols(searchQuery) {
+		const symbol = searchQuery.slice(0, 1);
+		const symbolData = self.allSymbols[symbol];
+		if (symbolData) {
+			const symbolEngines = self.allSymbols[symbol].engines;
+			const symbolName = self.allSymbols[symbol].name;
+			return _createSuggestions({
+				searchQuery,
+				symbol,
+				symbolEngines,
+				symbolName,
+			});
+		} else {
+			return _createSuggestions({ searchQuery });
+		}
+	},
+};
+
+const _createSuggestions = ({
+	searchQuery,
+	symbol,
+	symbolEngines,
+	symbolName,
+}) => {
+	const matchingEngines = self.allEngines.filter((engineData) => {
+		const [eSymbol, eId, eUrl, eSearch] = engineData;
+		return eSearch.includes(searchQuery);
+	});
+	console.log("matchingEngines", matchingEngines);
+	const suggestedEngines = matchingEngines.map((engineData) => {
+		const [eSymbol, eId, eUrl, eSearch] = engineData;
+		return [eSymbol, eId];
+	});
+	return [searchQuery, suggestedEngines];
+};
+
+const _mergeSymbols = (symbols, userSymbols) => {
+	return Object.keys(symbols).reduce((acc, currKey) => {
+		acc[currKey] = {
+			engines: { ...symbols[currKey].engines },
+		};
+		acc[currKey] = {
+			engines: { ...acc[currKey]?.engines, ...userSymbols[currKey]?.engines },
+		};
+		acc[currKey].name = symbols[currKey].name;
+		return acc;
+	}, {});
+};
+
+const _mergeEngines = (allSymbols) => {
+	return Object.keys(allSymbols).reduce((acc, symbol) => {
+		const symbolData = allSymbols[symbol];
+		const symbolEngines = Object.entries(symbolData.engines);
+		const engines = [
+			...acc,
+			...symbolEngines.map(([engine, url]) => {
+				return [symbol, engine, url, `${symbol + engine + " " + url}`];
+			}),
+		];
+		return engines;
+	}, []);
+};
+
+const _handleFetch = (event) => {
+	console.log("sw handle fetch", event.request.url);
+	const url = new URL(event.request.url);
+	if (url.pathname === "/api") {
+		return event.respondWith(_respondWithApiRoot(event.request));
+	} else if (url.pathname.startsWith("/api/suggestions")) {
+		return event.respondWith(_respondWithSuggestions(event.request));
+	} else {
+		return self.fetch(event.request.url);
+	}
+};
+
+const _respondWithSuggestions = (request) => {
+	// Parse the hash query param from the request URL
+	const url = new URL(request.url);
+	const params = new URLSearchParams(url.hash.slice(1));
+	const searchQuery = params.get("q");
+	let suggestionBody;
+	try {
+		suggestionBody = Find.suggestSymbols(searchQuery);
+	} catch (e) {
+		console.info("Could not fetch any suggestion", e);
+	}
+	/* https://stackoverflow.com/questions/36535642/serving-an-opensearch-application-x-suggestionsjson-through-a-service-worker */
+	return new Response(JSON.stringify(suggestionBody), {
+		status: 200,
+		headers: { "Content-Type": "application/x-suggestions+json" },
+	});
+};
+
+const _respondWithApiRoot = (request) => {
+	const body = {
+		message: "Welcome to the client side Find API",
+		suggestions: "api/sugestions#q={searchTerms}",
+	};
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "Content-Type": "application/x-suggestions+json" },
+	});
+};
+
+const _handleMessage = ({ data }) => {
+	const { symbols, userSymbols } = JSON.parse(data);
+	/* assign the data on the worker self global object;
+		 so we can re-use these values in the suggestions */
+	self.symbols = symbols;
+	self.userSymbols = userSymbols;
+	self.allSymbols = _mergeSymbols(symbols, userSymbols);
+	self.allEngines = _mergeEngines(self.allSymbols);
+};
+
+self.addEventListener("install", (event) => {
+	console.info("Service worker installed");
+});
+
+self.addEventListener("activate", (event) => {
+	console.info("Service worker activated");
+});
+
+self.addEventListener("fetch", _handleFetch);
+
+self.addEventListener("message", _handleMessage);

--- a/src/tests/open-search.js
+++ b/src/tests/open-search.js
@@ -8,7 +8,7 @@ const CONFIG_EXPORT = {
 	templateHTML: "https://internet4000.github.io/find/#q={searchTerms}",
 	templateXML: "https://internet4000.github.io/find/public/opensearch.xml",
 	templateSuggestionsJSON:
-		"https://internet4000.github.io/find/public/suggestions.json",
+		"https://internet4000.github.io/find/api/suggestions/#q={searchTerms}",
 };
 
 const XML_EXPORT = `<?xml version="1.0" encoding="UTF-8"?>
@@ -17,8 +17,8 @@ const XML_EXPORT = `<?xml version="1.0" encoding="UTF-8"?>
 	<Description>Find anything anywhere</Description>
 	<Image height="64" width="64" type="image/png">https://internet4000.github.io/find/public/favicon.ico</Image>
 	<Url type="text/html" template="https://internet4000.github.io/find/#q={searchTerms}" />
-	<Url type="application/opensearchdescription+xml" rel="self" template="https://internet4000.github.io/find/public/opensearch.xml" />
-	<Url type="application/x-suggestions+json" template="https://internet4000.github.io/find/public/suggestions.json" />
+	<Url type="application/opensearchdescription+xml" rel="search" template="https://internet4000.github.io/find/public/opensearch.xml" />
+	<Url type="application/x-suggestions+json" template="https://internet4000.github.io/find/api/suggestions/#q={searchTerms}" />
 </OpenSearchDescription>`;
 
 test("OpenSearchDescription is in Find with a config", (t) => {


### PR DESCRIPTION
- add `service-worker.js` to catch fetch requests made to `/api/suggestions`.
- client side api endpoints `/api/{suggestions}/#q={searchTerms}` that should behave similarely to open search suggestions api
- render suggestions in the search input
- hopefully firefox/chromium omnibox can will call the endpoint, which will be caught by the service worker, and return local search, even when no "find instance tab is opened" (but the browser is, and find has been opened once, so the service worker registered, and maybe find is the default search engine)

Docs:
- https://developer.mozilla.org/en-US/docs/Web/OpenSearch
- https://stackoverflow.com/questions/36535642/serving-an-opensearch-application-x-suggestionsjson-through-a-service-worker