### PR TITLE
Replace Google Draw with tldraw

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -89,7 +89,7 @@ complete an action; add a item to a library, create a drawing, find a random
 image or text etc.
 
 - `+r4 [url]` - add a new track to a radio4000, from a youtube URL
-- `+draw [title]` - open a new drawing in Google Drive Draw
+- `+draw` - create a new drawing in tldraw
 - `+doc [title]` - open a new Google Docs document
 - `+sheet` - open a new Google Spreadsheets document
 - `+gmail` - open a new Gmail (Google Mail) email

--- a/readme.md
+++ b/readme.md
@@ -200,8 +200,8 @@ Example `do` with `+` symbol:
 ;; create a new google spreadsheet (with a title)
 +sheet my new sheet
 
-;; draw a new "google draw"
-+draw hello world
+;; make a drawing
++draw 
 
 ;; take a note
 +note My note content

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ export class I4kFindSymbols {
 				uri: encodeURIComponent("+"),
 				engines: {
 					aurl: "https://web.archive.org/save/{}",
-					draw: "https://docs.google.com/drawings/create?title={}",
+					draw: "https://www.tldraw.com",
 					/*
 						 WebBrowsers cannot directly open "data URLs",
 						 so (we will generate a goog.space with the "data URL to copy",


### PR DESCRIPTION
This PR makes `+draw` use tldraw instead of Google Draw.

Tldraw seems like a nicer alternative. It doesn't support specificing a title via the URL tho.